### PR TITLE
Use username/password authentication to test IBM MQ in the integration tests

### DIFF
--- a/src/integration/java/com/ibm/eventstreams/connect/mqsource/AbstractJMSContextIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsource/AbstractJMSContextIT.java
@@ -47,11 +47,15 @@ public class AbstractJMSContextIT {
 
     private static final String QMGR_NAME = "MYQMGR";
     private static final String CHANNEL_NAME = "DEV.APP.SVRCONN";
+    protected static final String APP_PASSWORD = "MySuperSecretPassword";
+    private static final String ADMIN_PASSWORD = "MyAdminPassword";
 
     @ClassRule
     public static GenericContainer<?> mqContainer = new GenericContainer<>("icr.io/ibm-messaging/mq:latest")
         .withEnv("LICENSE", "accept")
         .withEnv("MQ_QMGR_NAME", QMGR_NAME)
+        .withEnv("MQ_APP_PASSWORD", APP_PASSWORD)
+        .withEnv("MQ_ADMIN_PASSWORD", ADMIN_PASSWORD)
         .withEnv("MQ_ENABLE_EMBEDDED_WEB_SERVER", "false")
         .withExposedPorts(1414);
 
@@ -72,7 +76,7 @@ public class AbstractJMSContextIT {
             mqcf.setQueueManager(QMGR_NAME);
             mqcf.setConnectionNameList(getConnectionName());
 
-            jmsContext = mqcf.createContext();
+            jmsContext = mqcf.createContext("app", APP_PASSWORD);
         }
 
         return jmsContext;
@@ -127,7 +131,8 @@ public class AbstractJMSContextIT {
         cf.setStringProperty(WMQConstants.WMQ_CHANNEL, getChannelName());
         cf.setIntProperty(WMQConstants.WMQ_CONNECTION_MODE, WMQConstants.WMQ_CM_CLIENT);
         cf.setStringProperty(WMQConstants.WMQ_QUEUE_MANAGER, getQmgrName());
-        cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, false);
+        cf.setStringProperty(WMQConstants.USERID, "app");
+        cf.setStringProperty(WMQConstants.PASSWORD, APP_PASSWORD);
 
         connection = cf.createConnection();
         session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
@@ -163,7 +168,8 @@ public class AbstractJMSContextIT {
         cf.setStringProperty(WMQConstants.WMQ_CHANNEL, getChannelName());
         cf.setIntProperty(WMQConstants.WMQ_CONNECTION_MODE, WMQConstants.WMQ_CM_CLIENT);
         cf.setStringProperty(WMQConstants.WMQ_QUEUE_MANAGER, getQmgrName());
-        cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, false);
+        cf.setStringProperty(WMQConstants.USERID, "app");
+        cf.setStringProperty(WMQConstants.PASSWORD, APP_PASSWORD);
 
         connection = cf.createConnection();
         session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);

--- a/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskIT.java
+++ b/src/integration/java/com/ibm/eventstreams/connect/mqsource/MQSourceTaskIT.java
@@ -61,6 +61,9 @@ public class MQSourceTaskIT extends AbstractJMSContextIT {
         props.put("mq.channel.name", getChannelName());
         props.put("mq.queue", MQ_QUEUE);
         props.put("mq.user.authentication.mqcsp", "false");
+        props.put("mq.user.name", "app");
+        props.put("mq.password", APP_PASSWORD);
+        props.put("mq.user.authentication.mqcsp", "true");
         return props;
     }
 


### PR DESCRIPTION
# Description

The commit https://github.com/ibm-messaging/mq-container/commit/a8ff0a597ce1e72b4a85a8abff771002205c421c changed the handling of passwords for the developer configuration. Therefore, it is necessary to explicitly set them in the container environment and for the client properties.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

It fixes the integration tests.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
